### PR TITLE
scripting/destroying-game-objects-from-within-scripts

### DIFF
--- a/src/silly_sprites/CMakeLists.txt
+++ b/src/silly_sprites/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(sillysprites
         script/class_info.cpp
         script/object.hpp
         script/function.hpp
+        script/type_info.hpp
 )
 
 target_link_libraries(sillysprites

--- a/src/silly_sprites/application.cpp
+++ b/src/silly_sprites/application.cpp
@@ -9,7 +9,7 @@ namespace sly {
         : m_settings{ settings },
           m_script_engine{ std::make_unique<script::Engine>() } {
         m_script_engine->create_module("MyModule", "src/silly_sprites/test.as");
-        m_scenes.push_back(std::make_unique<Scene>());
+        m_scenes.push_back(std::make_unique<Scene>(this));
     }
 
     Application::~Application() = default;
@@ -61,7 +61,7 @@ namespace sly {
 
     void Application::update(Time const time) {
         for (auto& scene : m_scenes) {
-            scene->update(*this, time);
+            scene->update(time);
         }
     }
 

--- a/src/silly_sprites/game_object_and_scene.hpp
+++ b/src/silly_sprites/game_object_and_scene.hpp
@@ -52,6 +52,8 @@ namespace sly {
             (add_component(std::forward<Components>(components)), ...);
         }
 
+        void destroy();
+
         explicit operator Entity() const {
             return m_entity;
         }
@@ -100,6 +102,10 @@ namespace sly {
     template<typename Component>
     void GameObject::remove_component() {
         m_scene->template remove_component<Component>(*this);
+    }
+
+    inline void GameObject::destroy() {
+        m_scene->destroy(*this);
     }
 
 } // namespace sly

--- a/src/silly_sprites/script.hpp
+++ b/src/silly_sprites/script.hpp
@@ -11,7 +11,7 @@ namespace sly {
         tl::optional<script::Object> instance{ tl::nullopt };
 
     public:
-        explicit Script(std::string class_name) : class_name{ std::move(class_name) } { }
+        explicit Script(std::string class_name_) : class_name{ std::move(class_name_) } { }
     };
 
 } // namespace sly

--- a/src/silly_sprites/script.hpp
+++ b/src/silly_sprites/script.hpp
@@ -7,8 +7,11 @@
 namespace sly {
 
     struct Script {
-        std::string class_name{ "Player" };
-        tl::optional<script::Object> instance;
+        std::string class_name;
+        tl::optional<script::Object> instance{ tl::nullopt };
+
+    public:
+        explicit Script(std::string class_name) : class_name{ std::move(class_name) } { }
     };
 
 } // namespace sly

--- a/src/silly_sprites/script/builtins.cpp
+++ b/src/silly_sprites/script/builtins.cpp
@@ -1,47 +1,59 @@
 #include "builtins.hpp"
+#include "game_object_and_scene.hpp"
 #include <iostream>
 #include <spdlog/spdlog.h>
 
-void print(std::string const& text) {
-    std::cout << text;
-}
+namespace sly::script::builtins {
 
-void println(std::string const& text) {
-    std::cout << text << '\n';
-}
-
-void eprint(std::string const& text) {
-    std::cerr << text;
-}
-
-void eprintln(std::string const& text) {
-    std::cerr << text << '\n';
-}
-
-namespace logging {
-
-    void trace(std::string const& text) {
-        spdlog::trace(text);
+    void destroy() {
+        if (not g_current_script_execution_context.has_value()) {
+            spdlog::error("cannot destroy since execution context has not been set");
+            return;
+        }
+        g_current_script_execution_context->game_object->destroy();
     }
 
-    void debug(std::string const& text) {
-        spdlog::debug(text);
+    void print(std::string const& text) {
+        std::cout << text;
     }
 
-    void info(std::string const& text) {
-        spdlog::info(text);
+    void println(std::string const& text) {
+        std::cout << text << '\n';
     }
 
-    void warning(std::string const& text) {
-        spdlog::warn(text);
+    void eprint(std::string const& text) {
+        std::cerr << text;
+    }
+    void eprintln(std::string const& text) {
+        std::cerr << text << '\n';
     }
 
-    void error(std::string const& text) {
-        spdlog::error(text);
-    }
+    namespace logging {
 
-    void critical(std::string const& text) {
-        spdlog::critical(text);
-    }
+        void trace(std::string const& text) {
+            spdlog::trace(text);
+        }
 
-} // namespace logging
+        void debug(std::string const& text) {
+            spdlog::debug(text);
+        }
+
+        void info(std::string const& text) {
+            spdlog::info(text);
+        }
+
+        void warning(std::string const& text) {
+            spdlog::warn(text);
+        }
+
+        void error(std::string const& text) {
+            spdlog::error(text);
+        }
+
+        void critical(std::string const& text) {
+            spdlog::critical(text);
+        }
+
+    } // namespace logging
+
+} // namespace sly::script::builtins

--- a/src/silly_sprites/script/builtins.hpp
+++ b/src/silly_sprites/script/builtins.hpp
@@ -16,7 +16,7 @@ namespace sly::script::builtins {
     struct ExecutionContext {
         GameObject* game_object;
 
-        ExecutionContext(GameObject* game_object) : game_object{ game_object } { }
+        ExecutionContext(GameObject* game_object_) : game_object{ game_object_ } { }
     };
 
     inline tl::optional<ExecutionContext> g_current_script_execution_context = tl::nullopt;

--- a/src/silly_sprites/script/builtins.hpp
+++ b/src/silly_sprites/script/builtins.hpp
@@ -1,18 +1,40 @@
 #pragma once
 
+#include "types.hpp"
 #include <iostream>
+#include <spdlog/spdlog.h>
 #include <string>
+#include <tl/optional.hpp>
 
-void print(std::string const& text);
-void println(std::string const& text);
-void eprint(std::string const& text);
-void eprintln(std::string const& text);
+namespace sly {
+    class Scene;
+    class GameObject;
+} // namespace sly
 
-namespace logging {
-    void trace(std::string const& text);
-    void debug(std::string const& text);
-    void info(std::string const& text);
-    void warning(std::string const& text);
-    void error(std::string const& text);
-    void critical(std::string const& text);
-} // namespace logging
+namespace sly::script::builtins {
+
+    struct ExecutionContext {
+        GameObject* game_object;
+
+        ExecutionContext(GameObject* game_object) : game_object{ game_object } { }
+    };
+
+    inline tl::optional<ExecutionContext> g_current_script_execution_context = tl::nullopt;
+
+    void destroy();
+
+    void print(std::string const& text);
+    void println(std::string const& text);
+    void eprint(std::string const& text);
+    void eprintln(std::string const& text);
+
+    namespace logging {
+        void trace(std::string const& text);
+        void debug(std::string const& text);
+        void info(std::string const& text);
+        void warning(std::string const& text);
+        void error(std::string const& text);
+        void critical(std::string const& text);
+    } // namespace logging
+
+} // namespace sly::script::builtins

--- a/src/silly_sprites/script/object.hpp
+++ b/src/silly_sprites/script/object.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "type_info.hpp"
 #include <angelscript.h>
 
 namespace sly::script {
@@ -7,8 +8,9 @@ namespace sly::script {
     class Object final {
     private:
         void* m_object;
+        TypeInfo m_type;
 
-        explicit Object(void* object) : m_object{ object } { }
+        explicit Object(void* object, TypeInfo type) : m_object{ object }, m_type{ std::move(type) } { }
 
         friend class Engine;
     };

--- a/src/silly_sprites/script/type_info.hpp
+++ b/src/silly_sprites/script/type_info.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <angelscript.h>
+#include <cassert>
+#include <utility>
+
+namespace sly::script {
+
+    class TypeInfo final {
+    private:
+        asITypeInfo* m_type_info{ nullptr };
+
+        TypeInfo() = default;
+
+        explicit TypeInfo(asITypeInfo* const type_info) : m_type_info{ type_info } {
+            assert(m_type_info != nullptr);
+            m_type_info->AddRef();
+        }
+
+    public:
+        TypeInfo(TypeInfo const& other) : m_type_info{ other.m_type_info } {
+            m_type_info->AddRef();
+        }
+
+        TypeInfo(TypeInfo&& other) noexcept : m_type_info{ std::exchange(other.m_type_info, nullptr) } { }
+
+        TypeInfo& operator=(TypeInfo const& other) {
+            if (this == &other) {
+                return *this;
+            }
+
+            if (m_type_info != nullptr) {
+                m_type_info->Release();
+            }
+
+            m_type_info = other.m_type_info;
+            if (m_type_info != nullptr) {
+                m_type_info->AddRef();
+            }
+
+            return *this;
+        }
+
+        TypeInfo& operator=(TypeInfo&& other) noexcept {
+            if (this == &other) {
+                return *this;
+            }
+            std::swap(m_type_info, other.m_type_info);
+            return *this;
+        }
+
+        ~TypeInfo() {
+            if (m_type_info != nullptr) {
+                m_type_info->Release();
+                m_type_info = nullptr;
+            }
+        }
+
+        friend class Engine;
+    };
+
+} // namespace sly::script

--- a/src/silly_sprites/test.as
+++ b/src/silly_sprites/test.as
@@ -1,87 +1,23 @@
-void main() {
-    print("Hello world");
-    println("Hello world");
-    print("Hello world");
-    println("Hello world");
-
-    datetime now();
-    eprintln(
-        now.get_day() + "."
-        + now.get_month() + "."
-        + now.get_year() + " "
-        + now.get_hour() + ":"
-        + now.get_minute() + ":"
-        + now.get_second()
-    );
-    eprintln(sin(2 + 2) + " is the result.");
-
-    Log::trace("catch me if you can");
-    Log::debug("this has the least priority");
-    Log::info("this is my log message");
-    Log::warning("attention please, may I have you attention please?!");
-    Log::warn("attention please, may I have you attention please?!");
-    Log::error("may the real slim shady please stand up?! I repeat...");
-    Log::critical("may the real slim shady please stand up?!");
-}
-
-int solve(double p, double q, double &out x1, double &out x2) {
-    const double discriminant = (p / 2.0) * (p / 2.0) - q;
-    if (discriminant < 0.0) {
-        return 0;
-    }
-    if (discriminant == 0.0) {
-        x1 = -p / 2.0;
-        return 1;
-    }
-    x1 = -p / 2.0 + sqrt(discriminant);
-    x2 = -p / 2.0 - sqrt(discriminant);
-    return 2;
-}
-
-int add(int a, int b) {
-    return a + b;
-}
-
-uint test(const string &in text) {
-    eprintln("Hello, world!");
-    eprintln("This is AngelScript saying 'hello!', " + text);
-    return text.length();
-}
-
-uint64 num_player_instances = 0;
-
 class Player {
-    uint64 countdown = 0;
-    int kind = 0;
-
-    Player() {
-        ++num_player_instances;
-        Log::warning("this is instance #" + num_player_instances);
-        kind = num_player_instances % 2;
-        reset_countdown();
-    }
-
-    void reset_countdown() {
-        if (kind == 0) {
-            countdown = 100000;
-        } else {
-            countdown = 50000;
-        }
-    }
+    private double next_log_time = 0.0;
 
     void awake() {
         Log::critical("rise and shine!");
     }
 
-    void update() {
-        --countdown;
-        if (countdown == 0) {
-            reset_countdown();
-            if (kind == 0) {
-                Log::info("countdown reset");
-            } else {
-                Log::warning("countdown reset");
-            }
+    void update(Time time) {
+        if (next_log_time == 0.0) {
+            next_log_time = time.elapsed + 0.5;
+        }
+
+        if (time.elapsed >= next_log_time) {
+            Log::info("waiting for time to pass by...");
+            next_log_time = time.elapsed + 0.5;
+        }
+
+        if (time.elapsed >= 2.0) {
+            Log::info("destroying game object");
+            destroy();
         }
     }
 }


### PR DESCRIPTION
It's now possible to destroy game objects from within scripts (at the moment only the game object, the script is running on). Different additional API elements have been exposed to AngelScript.
This is not finished yet, but I don't want the PR to grow much bigger.